### PR TITLE
New tree logic update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ hashbrown = { version = "0.13.2", default-features = false, features = ["ahash"]
 memory-db = { version = "0.29.0"}
 
 [dev-dependencies]
+rs_merkle = "1.2.0"
+sha2 = { version = "0.10", default-features = false }
 sha3 = { version = "0.10" }
 hash256-std-hasher = { version = "0.15.2" }
 memory-db = { version = "0.29.0"}

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,16 +15,12 @@ impl core::fmt::Display for TreeError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         use TreeError::*;
         match self {
-            DataError(err) => write!(f, "Data Error: {}", err),
-            NodeError(err) => write!(f, "Node Error: {}", err),
+            DataError(err) => write!(f, "Data Error: {err}"),
+            NodeError(err) => write!(f, "Node Error: {err}"),
             DepthTooLarge(actual, max) => {
-                write!(
-                    f,
-                    "depth too large {} - max supported depth is {}",
-                    actual, max
-                )
+                write!(f, "depth {actual} too large - max supported depth is {max}",)
             }
-            KeyError(err) => write!(f, "key error: {}", err),
+            KeyError(err) => write!(f, "key error: {err}"),
         }
     }
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -22,16 +22,6 @@ impl<const N: usize> Key<N> {
         Ok(Key(key))
     }
 
-    /// Create a zero key
-    pub const fn zero() -> Self {
-        Self([0u8; N])
-    }
-
-    /// Returns true if the key is the zero key, false otherwise
-    pub fn is_zero(&self) -> bool {
-        self == &Key::zero()
-    }
-
     /// Returns the bit at the i'th index of the key
     pub fn bit(&self, i: usize) -> Result<bool, KeyError> {
         let byte_pos = i / BYTE_SIZE;
@@ -54,14 +44,6 @@ impl<const N: usize> Key<N> {
         KeyIter {
             key: self,
             element: 0,
-        }
-    }
-
-    /// Returns an iterator over the key from the i'th index
-    pub fn iter_from(&self, i: usize) -> KeyIter<'_, N> {
-        KeyIter {
-            key: self,
-            element: i,
         }
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -49,16 +49,6 @@ impl<H: Hasher> NodeStorage<H> {
             .and_then(|node| self.nodes.remove(hash).map(|_| node))
     }
 
-    /// check if a node is in the storage
-    pub fn contains(&self, hash: &H::Out) -> bool {
-        self.nodes.contains_key(hash)
-    }
-
-    /// check if the storage is empty
-    pub fn is_empty(&self) -> bool {
-        self.nodes.is_empty()
-    }
-
     /// iterate over key - value pairs of the storage
     pub fn iter(&self) -> hashbrown::hash_map::Iter<H::Out, (Node<H>, usize)> {
         self.nodes.iter()

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -133,7 +133,7 @@ pub trait TreeRecorder<H: Hasher> {
 // ================================================================================================
 
 /// Return the HashMap hashing node hash to Node for null nodes of a tree of depth D
-pub fn null_nodes<H: Hasher>(depth: usize) -> HashMap<H::Out, Node<H>> {
+pub fn null_nodes<H: Hasher>(depth: usize) -> (HashMap<H::Out, Node<H>>, H::Out) {
     let mut hashes = HashMap::with_capacity(depth);
     let mut current_hash = H::hash(&[]);
 
@@ -145,7 +145,7 @@ pub fn null_nodes<H: Hasher>(depth: usize) -> HashMap<H::Out, Node<H>> {
         },
     );
 
-    for _ in 1..depth {
+    for _ in 0..depth {
         let next_hash = H::hash(&[current_hash.as_ref(), current_hash.as_ref()].concat());
         hashes.insert(
             next_hash,
@@ -158,5 +158,5 @@ pub fn null_nodes<H: Hasher>(depth: usize) -> HashMap<H::Out, Node<H>> {
         current_hash = next_hash;
     }
 
-    hashes
+    (hashes, current_hash)
 }

--- a/src/treedbmut.rs
+++ b/src/treedbmut.rs
@@ -47,6 +47,11 @@ impl<'db, const D: usize, H: Hasher> TreeDBMutBuilder<'db, D, H> {
         self
     }
 
+    pub fn default_root() -> H::Out {
+        let (_, default_root) = null_nodes::<H>(D * 8);
+        default_root
+    }
+
     /// Consumes the builder and returns a TreeDBMut
     pub fn build(self) -> TreeDBMut<'db, D, H> {
         let (null_nodes, default_root) = null_nodes::<H>(D * 8);


### PR DESCRIPTION
This PR allows the user to construct a `TreeDB` and a `TreeDBMut` using a default hash `H::Out::default()` or the root of an empty tree of appropriate depth and using the hasher specified via generics. 

The PR also includes some cleanup chores and an additional test to assert consistency with the `rs_merkle` library.

closes: #7 
supports: #3 