### PR TITLE
Update library name in examples and add examples to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,25 @@ jobs:
         with:
           command: test
 
+  examples:
+    name: Examples
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        args: ["--example index_tree --features executable", "--example keyed_tree --features executable", "--example recorder --features executable"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: ${{matrix.args}}
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/examples/index_tree.rs
+++ b/examples/index_tree.rs
@@ -1,9 +1,7 @@
-use binary_merkle_tree::{
-    Hasher, IndexTree, IndexTreeDBBuilder, IndexTreeDBMutBuilder, IndexTreeMut,
-};
 use hash256_std_hasher::Hash256StdHasher;
 use hash_db::Prefix;
 use memory_db::{KeyFunction, MemoryDB};
+use merkle_tree_db::{Hasher, IndexTree, IndexTreeDBBuilder, IndexTreeDBMutBuilder, IndexTreeMut};
 use sha3::{Digest, Sha3_256};
 use std::marker::PhantomData;
 

--- a/examples/keyed_tree.rs
+++ b/examples/keyed_tree.rs
@@ -1,7 +1,7 @@
-use binary_merkle_tree::{Hasher, KeyedTree, KeyedTreeMut, TreeDBBuilder, TreeDBMutBuilder};
 use hash256_std_hasher::Hash256StdHasher;
 use hash_db::Prefix;
 use memory_db::{KeyFunction, MemoryDB};
+use merkle_tree_db::{Hasher, KeyedTree, KeyedTreeMut, TreeDBBuilder, TreeDBMutBuilder};
 use sha3::{Digest, Sha3_256};
 use std::marker::PhantomData;
 

--- a/examples/recorder.rs
+++ b/examples/recorder.rs
@@ -1,9 +1,7 @@
-use binary_merkle_tree::{
-    Hasher, KeyedTree, KeyedTreeMut, Recorder, TreeDBBuilder, TreeDBMutBuilder,
-};
 use hash256_std_hasher::Hash256StdHasher;
 use hash_db::Prefix;
 use memory_db::{KeyFunction, MemoryDB};
+use merkle_tree_db::{Hasher, KeyedTree, KeyedTreeMut, Recorder, TreeDBBuilder, TreeDBMutBuilder};
 use sha3::{Digest, Sha3_256};
 use std::marker::PhantomData;
 


### PR DESCRIPTION
This PR updates the library name in the examples which was causing the examples to fail and also enhanced the CI such that the examples are run.