### PR TITLE
Make crate no_std compatible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,18 +4,25 @@ name: Continuous integration
 
 jobs:
   check:
-    name: Check
-    runs-on: ubuntu-latest
+    name: Check Rust ${{matrix.toolchain}} on ${{matrix.os}} with ${{matrix.args}}
+    runs-on: ${{matrix.os}}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [stable]
+        os: [ubuntu]
+        args: [--all-targets --no-default-features, --all-targets, --all-targets --all-features]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{matrix.toolchain}}
           override: true
       - uses: actions-rs/cargo@v1
         with:
           command: check
+          args: ${{matrix.args}}
 
   test:
     name: Test Suite

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,8 @@
 /// - NodeError - errors associated with the nodes in the tree
 /// - DepthTooLarge - error returned when the specified tree depth is too large
 /// - KeyError - error associated with the key used to access the tree
+use super::rstd::{string::String, vec::Vec};
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum TreeError {
     DataError(DataError),

--- a/src/indexdb.rs
+++ b/src/indexdb.rs
@@ -1,6 +1,6 @@
 use super::{
-    DBValue, HashDBRef, Hasher, IndexTree, Key, KeyedTree, TreeDB, TreeDBBuilder, TreeError,
-    TreeRecorder,
+    rstd::vec::Vec, DBValue, HashDBRef, Hasher, IndexTree, Key, KeyedTree, TreeDB, TreeDBBuilder,
+    TreeError, TreeRecorder,
 };
 
 // IndexTreeDBBuilder

--- a/src/indexdbmut.rs
+++ b/src/indexdbmut.rs
@@ -1,6 +1,6 @@
 use super::{
-    DBValue, HashDB, Hasher, IndexTreeMut, Key, KeyedTreeMut, TreeDBMut, TreeDBMutBuilder,
-    TreeError, TreeRecorder,
+    rstd::vec::Vec, DBValue, HashDB, Hasher, IndexTreeMut, Key, KeyedTreeMut, TreeDBMut,
+    TreeDBMutBuilder, TreeError, TreeRecorder,
 };
 
 // IndexTreeDBMutBuilder

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,11 @@
 //! serve this purpose. This library supports both indexed merkle trees (max depth 64) and keyed
 //! (addressable) merkle trees (max depth usize::MAX).
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 mod error;
 mod indexdb;
 mod indexdbmut;
@@ -24,12 +29,24 @@ mod tests;
 // INTERNALS
 // ================================================================================================
 
+#[cfg(feature = "std")]
+mod rstd {
+    pub use std::{fmt, iter, string, vec};
+}
+
+#[cfg(not(feature = "std"))]
+mod rstd {
+    pub use alloc::{string, vec};
+    pub use core::{fmt, iter};
+}
+
 use error::{DataError, KeyError, NodeError};
 use key::Key;
 use node::{ChildSelector, Node, NodeHash};
 use storage::NodeStorage;
 use tree::null_nodes;
 
+use self::rstd::vec::Vec;
 use hashbrown::{HashMap, HashSet};
 
 // RE-EXPORTS

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,5 +1,11 @@
-use super::{DBValue, Hasher, NodeError};
+use super::{
+    rstd::{string::ToString, vec, vec::Vec},
+    DBValue, Hasher, NodeError,
+};
 use core::ops::Deref;
+
+#[cfg(feature = "std")]
+use super::rstd::fmt;
 
 // NodeHash
 // ================================================================================================
@@ -18,8 +24,9 @@ pub enum NodeHash<H: Hasher> {
     Default(H::Out),
 }
 
-impl<H: Hasher> core::fmt::Display for NodeHash<H> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+#[cfg(feature = "std")]
+impl<H: Hasher> fmt::Display for NodeHash<H> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             NodeHash::InMemory(hash) => write!(f, "InMemory({hash:?})"),
             NodeHash::Database(hash) => write!(f, "Database({hash:?})"),
@@ -115,8 +122,9 @@ pub enum Node<H: Hasher> {
     },
 }
 
-impl<H: Hasher> std::fmt::Display for Node<H> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+#[cfg(feature = "std")]
+impl<H: Hasher> fmt::Display for Node<H> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Node::Value { hash, value } => write!(f, "Value({hash:?}, {value:?})"),
             Node::Inner { hash, left, right } => write!(f, "Inner({hash:?}, {left}, {right})"),

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -1,8 +1,10 @@
-use super::{HashSet, Hasher};
+use super::{
+    rstd::{iter::IntoIterator, vec::Vec},
+    HashSet, Hasher,
+};
 use core::marker::PhantomData;
 use hash_db::{AsHashDB, Prefix, EMPTY_PREFIX};
 use memory_db::{KeyFunction, MemoryDB};
-use std::iter::IntoIterator;
 
 // StorageProof
 // ================================================================================================

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,14 +1,15 @@
 use super::{
+    rstd::{vec, vec::Vec},
     DBValue, Hasher, IndexTree, IndexTreeDB, IndexTreeDBBuilder, IndexTreeDBMut,
     IndexTreeDBMutBuilder, IndexTreeMut, KeyedTree, KeyedTreeMut, Recorder, TreeDB, TreeDBBuilder,
     TreeDBMut, TreeDBMutBuilder,
 };
 
+use core::marker::PhantomData;
 use hash256_std_hasher::Hash256StdHasher;
 use hash_db::Prefix;
 use memory_db::{KeyFunction, MemoryDB};
 use sha3::{Digest, Sha3_256};
-use std::marker::PhantomData;
 
 // MOCK
 // ================================================================================================

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,4 +1,7 @@
-use super::{DBValue, HashMap, Hasher, Node, NodeHash, TreeError};
+use super::{
+    rstd::{vec, vec::Vec},
+    DBValue, HashMap, Hasher, Node, NodeHash, TreeError,
+};
 
 // TRAITS
 // ================================================================================================

--- a/src/treedb.rs
+++ b/src/treedb.rs
@@ -1,8 +1,8 @@
 use hash_db::{HashDBRef, EMPTY_PREFIX};
 
 use super::{
-    null_nodes, ChildSelector, DBValue, DataError, HashMap, Hasher, Key, KeyedTree, Node, NodeHash,
-    TreeError, TreeRecorder,
+    null_nodes, rstd::vec::Vec, ChildSelector, DBValue, DataError, HashMap, Hasher, Key, KeyedTree,
+    Node, NodeHash, TreeError, TreeRecorder,
 };
 
 // TreeDBBuilder

--- a/src/treedbmut.rs
+++ b/src/treedbmut.rs
@@ -1,6 +1,8 @@
 use super::{
-    null_nodes, ChildSelector, DBValue, DataError, HashDBRef, HashMap, Hasher, Key, KeyedTreeMut,
-    Node, NodeHash, NodeStorage, TreeError, TreeRecorder,
+    null_nodes,
+    rstd::{vec, vec::Vec},
+    ChildSelector, DBValue, DataError, HashDBRef, HashMap, Hasher, Key, KeyedTreeMut, Node,
+    NodeHash, NodeStorage, TreeError, TreeRecorder,
 };
 use core::cmp::Ordering;
 use hash_db::{HashDB, EMPTY_PREFIX};


### PR DESCRIPTION
PR for [Issue](https://github.com/frisitano/merkle-tree-db/issues/9)

Solution:
1. lib.rs contain declarations which get toggled based on the std and no_std compatibility.
2. Node and NodeHash fmt method will work only for std modules.



